### PR TITLE
add-results-task-pane

### DIFF
--- a/Genizah/Genizah.csproj
+++ b/Genizah/Genizah.csproj
@@ -166,12 +166,31 @@
     <Compile Include="CensorSettingsDialog.Designer.cs">
       <DependentUpon>CensorSettingsDialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="Results\ResultControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Results\ResultControl.Designer.cs">
+      <DependentUpon>ResultControl.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Results\ResultsControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Results\ResultsControl.Designer.cs">
+      <DependentUpon>ResultsControl.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Results\SearchResult.cs" />
     <Compile Include="NameInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
     <EmbeddedResource Include="CensorControls.resx">
       <DependentUpon>CensorControls.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Results\ResultControl.resx">
+      <DependentUpon>ResultControl.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Results\ResultsControl.resx">
+      <DependentUpon>ResultsControl.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/Genizah/Results/ResultControl.Designer.cs
+++ b/Genizah/Results/ResultControl.Designer.cs
@@ -1,0 +1,88 @@
+﻿namespace Genizah
+{
+    partial class ResultControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ResultControl));
+            this.undoButton = new System.Windows.Forms.Button();
+            this.originalTextLabel = new System.Windows.Forms.Label();
+            this.replacementTextLabel = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // undoButton
+            // 
+            this.undoButton.Image = ((System.Drawing.Image)(resources.GetObject("undoButton.Image")));
+            this.undoButton.Location = new System.Drawing.Point(38, 21);
+            this.undoButton.Name = "undoButton";
+            this.undoButton.Size = new System.Drawing.Size(22, 19);
+            this.undoButton.TabIndex = 2;
+            this.undoButton.UseVisualStyleBackColor = true;
+            this.undoButton.Click += new System.EventHandler(this.UndoHandler);
+            // 
+            // originalTextLabel
+            // 
+            this.originalTextLabel.AutoSize = true;
+            this.originalTextLabel.Location = new System.Drawing.Point(130, 22);
+            this.originalTextLabel.Name = "originalTextLabel";
+            this.originalTextLabel.Size = new System.Drawing.Size(41, 16);
+            this.originalTextLabel.TabIndex = 3;
+            this.originalTextLabel.Text = "oText";
+            this.originalTextLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // replacementTextLabel
+            // 
+            this.replacementTextLabel.AutoSize = true;
+            this.replacementTextLabel.Location = new System.Drawing.Point(86, 22);
+            this.replacementTextLabel.Name = "replacementTextLabel";
+            this.replacementTextLabel.Size = new System.Drawing.Size(37, 16);
+            this.replacementTextLabel.TabIndex = 4;
+            this.replacementTextLabel.Text = "rText";
+            this.replacementTextLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // ResultControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.replacementTextLabel);
+            this.Controls.Add(this.originalTextLabel);
+            this.Controls.Add(this.undoButton);
+            this.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.Name = "ResultControl";
+            this.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.Size = new System.Drawing.Size(219, 58);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        private System.Windows.Forms.Button undoButton;
+        private System.Windows.Forms.Label originalTextLabel;
+        private System.Windows.Forms.Label replacementTextLabel;
+    }
+}

--- a/Genizah/Results/ResultControl.Designer.cs
+++ b/Genizah/Results/ResultControl.Designer.cs
@@ -28,28 +28,33 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ResultControl));
             this.undoButton = new System.Windows.Forms.Button();
             this.originalTextLabel = new System.Windows.Forms.Label();
             this.replacementTextLabel = new System.Windows.Forms.Label();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.SuspendLayout();
             // 
             // undoButton
             // 
             this.undoButton.Image = ((System.Drawing.Image)(resources.GetObject("undoButton.Image")));
-            this.undoButton.Location = new System.Drawing.Point(38, 21);
+            this.undoButton.Location = new System.Drawing.Point(19, 3);
+            this.undoButton.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.undoButton.Name = "undoButton";
-            this.undoButton.Size = new System.Drawing.Size(22, 19);
+            this.undoButton.Size = new System.Drawing.Size(22, 24);
             this.undoButton.TabIndex = 2;
+            this.toolTip1.SetToolTip(this.undoButton, "ביטול הצינזור");
             this.undoButton.UseVisualStyleBackColor = true;
             this.undoButton.Click += new System.EventHandler(this.UndoHandler);
             // 
             // originalTextLabel
             // 
             this.originalTextLabel.AutoSize = true;
-            this.originalTextLabel.Location = new System.Drawing.Point(130, 22);
+            this.originalTextLabel.Location = new System.Drawing.Point(138, 9);
+            this.originalTextLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.originalTextLabel.Name = "originalTextLabel";
-            this.originalTextLabel.Size = new System.Drawing.Size(41, 16);
+            this.originalTextLabel.Size = new System.Drawing.Size(34, 13);
             this.originalTextLabel.TabIndex = 3;
             this.originalTextLabel.Text = "oText";
             this.originalTextLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -57,24 +62,27 @@
             // replacementTextLabel
             // 
             this.replacementTextLabel.AutoSize = true;
-            this.replacementTextLabel.Location = new System.Drawing.Point(86, 22);
+            this.replacementTextLabel.Location = new System.Drawing.Point(88, 9);
+            this.replacementTextLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.replacementTextLabel.Name = "replacementTextLabel";
-            this.replacementTextLabel.Size = new System.Drawing.Size(37, 16);
+            this.replacementTextLabel.Size = new System.Drawing.Size(31, 13);
             this.replacementTextLabel.TabIndex = 4;
             this.replacementTextLabel.Text = "rText";
             this.replacementTextLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // ResultControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.replacementTextLabel);
             this.Controls.Add(this.originalTextLabel);
             this.Controls.Add(this.undoButton);
             this.Cursor = System.Windows.Forms.Cursors.Hand;
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.Name = "ResultControl";
             this.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.Size = new System.Drawing.Size(219, 58);
+            this.Size = new System.Drawing.Size(194, 32);
+            this.toolTip1.SetToolTip(this, "סימון");
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -84,5 +92,6 @@
         private System.Windows.Forms.Button undoButton;
         private System.Windows.Forms.Label originalTextLabel;
         private System.Windows.Forms.Label replacementTextLabel;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/Genizah/Results/ResultControl.cs
+++ b/Genizah/Results/ResultControl.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Windows.Forms;
+using Genizah.Results;
+using Microsoft.Office.Interop.Word;
+
+namespace Genizah
+{
+    public partial class ResultControl : UserControl
+    {
+        private Bookmark Bookmark { get; set; } = null;
+        private string OriginalText { get; set; }
+        public int RangeStart
+        { get { return this.Bookmark?.Start ?? -1; } }
+        public int RangeEnd
+        { get { return this.Bookmark?.End ?? -1; } }
+
+        public event EventHandler RemoveResultControlHandler;
+        public ResultControl(SearchResult result)
+        {
+            InitializeComponent();
+            this.MouseEnter += this.OnMouseEnter;
+            this.MouseLeave += this.OnMouseLeave;
+            this.Click += ClickHandler_SelectResult;
+            this.originalTextLabel.Click += ClickHandler_SelectResult;
+            this.replacementTextLabel.Click += ClickHandler_SelectResult;
+            this.Bookmark = result.Bookmark;
+            this.OriginalText = result.OriginalText;
+            originalTextLabel.Text = result.OriginalText;
+            replacementTextLabel.Text = result.ReplacementText;
+        }
+        private void OnMouseEnter(object sender, EventArgs e)
+        {
+            this.BorderStyle = BorderStyle.FixedSingle;
+        }
+        private void OnMouseLeave(object sender, EventArgs e)
+        {
+            if (!this.ClientRectangle.Contains(this.PointToClient(Control.MousePosition)))
+                this.BorderStyle = BorderStyle.None;
+        }
+        private void ClickHandler_SelectResult(object sender, EventArgs e)
+        {
+            Globals.ThisAddIn.Application.Selection.Start = this.RangeStart;
+            Globals.ThisAddIn.Application.Selection.End = this.RangeEnd;
+        }
+
+        private void UndoHandler(object sender, EventArgs e)
+        {
+            var doc = Globals.ThisAddIn.Application.ActiveDocument;
+            var range = doc.Range(this.RangeStart, this.RangeEnd);
+            range.Text = this.OriginalText;
+            range.HighlightColorIndex = 0;
+            RemoveResultControlHandler?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/Genizah/Results/ResultControl.resx
+++ b/Genizah/Results/ResultControl.resx
@@ -127,4 +127,7 @@
         bIB6UCjVgQuuDmSgdWBAADs=
 </value>
   </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/Genizah/Results/ResultControl.resx
+++ b/Genizah/Results/ResultControl.resx
@@ -1,0 +1,130 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="undoButton.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        R0lGODlhEAAQAIQAAAQCBIyKjERGRMzKzCQiJGxubOzq7LS2tFRWVDw6PBweHJyanNTW1Pz6/AwKDCwq
+        LHx6fGRiZIyOjExKTMzOzOzu7FxaXDw+PJyenNze3Pz+/AwODCwuLHx+fP///wAAACH/C05FVFNDQVBF
+        Mi4wAwEBAAAh+QQBAAAeACwAAAAAEAAQAAAIawA9CByoYaDBgx4aQBCAEKEBAQASNDQ4QAGAiBMFYrh4
+        0UECARECDDBYgKNJkw8OCCx5siUACQIXmHTwwOLJkR4o2JSYMAOGBBcRDHyI8aBMBQYbdJjQEAKAjAcN
+        bIB6UCjVgQuuDmSgdWBAADs=
+</value>
+  </data>
+</root>

--- a/Genizah/Results/ResultsControl.Designer.cs
+++ b/Genizah/Results/ResultsControl.Designer.cs
@@ -35,17 +35,19 @@
             // 
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(371, 217);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(200, 150);
             this.flowLayoutPanel1.TabIndex = 0;
             // 
             // ResultsControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.flowLayoutPanel1);
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.Name = "ResultsControl";
-            this.Size = new System.Drawing.Size(371, 217);
+            this.Size = new System.Drawing.Size(200, 150);
             this.ResumeLayout(false);
 
         }

--- a/Genizah/Results/ResultsControl.Designer.cs
+++ b/Genizah/Results/ResultsControl.Designer.cs
@@ -1,0 +1,57 @@
+﻿namespace Genizah
+{
+    partial class ResultsControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.SuspendLayout();
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(371, 217);
+            this.flowLayoutPanel1.TabIndex = 0;
+            // 
+            // ResultsControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.flowLayoutPanel1);
+            this.Name = "ResultsControl";
+            this.Size = new System.Drawing.Size(371, 217);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+    }
+}

--- a/Genizah/Results/ResultsControl.cs
+++ b/Genizah/Results/ResultsControl.cs
@@ -10,6 +10,8 @@ namespace Genizah
         public ResultsControl()
         {
             InitializeComponent();
+            this.flowLayoutPanel1.Dock = DockStyle.Fill;
+            this.flowLayoutPanel1.AutoScroll = true;
         }
 
         public void UpdateSearchResults(List<SearchResult> results)

--- a/Genizah/Results/ResultsControl.cs
+++ b/Genizah/Results/ResultsControl.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using Genizah.Results;
+
+namespace Genizah
+{
+    public partial class ResultsControl : UserControl
+    {
+        public ResultsControl()
+        {
+            InitializeComponent();
+        }
+
+        public void UpdateSearchResults(List<SearchResult> results)
+        {
+            foreach (var result in results.OrderBy(x => x.rangeStart))
+            {
+                ResultControl resultControl = new ResultControl(result);
+                resultControl.RemoveResultControlHandler += (sender, e) =>
+                {
+                    flowLayoutPanel1.Controls.Remove(resultControl);
+                };
+                flowLayoutPanel1.Controls.Add(resultControl);
+            }
+        }
+    }
+}

--- a/Genizah/Results/ResultsControl.resx
+++ b/Genizah/Results/ResultsControl.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Genizah/Results/SearchResult.cs
+++ b/Genizah/Results/SearchResult.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Office.Interop.Word;
+
+namespace Genizah.Results
+{
+    public class SearchResult
+    {
+        public string OriginalText { get; set; }
+        public string ReplacementText { get; set; }
+        public Bookmark Bookmark { get; set; }
+        public int rangeStart { get; set; }
+        public int rangeEnd { get; set; }
+    }
+}

--- a/Genizah/ThisAddIn.cs
+++ b/Genizah/ThisAddIn.cs
@@ -111,20 +111,23 @@ namespace Genizah
             {
                 while (findObject.Execute())
                 {
-                    var originalText = range.Text;
-                    range.Text = replacement;
+                    var rangeDuplicate = range.Duplicate;
+                    var containedWords = this.Application.ActiveDocument.Range(rangeDuplicate.Words.First.Start, rangeDuplicate.Words.Last.End);
+                    var originalText = target;
+                    rangeDuplicate.Text = replacement;
                     var bookmarkId = originalText + Guid.NewGuid().ToString().Split('-').First();
-                    Word.Bookmark bookmark = this.Application.ActiveDocument.Bookmarks.Add(bookmarkId, range);
-                    range.HighlightColorIndex = WdColorIndex.wdYellow;
+                    Word.Bookmark bookmark = this.Application.ActiveDocument.Bookmarks.Add(bookmarkId, rangeDuplicate);
+                    rangeDuplicate.HighlightColorIndex = WdColorIndex.wdYellow;
                     SearchResult result = new SearchResult()
                     {
                         Bookmark = bookmark,
-                        rangeStart = range.Start,
-                        rangeEnd = range.End,
+                        rangeStart = rangeDuplicate.Start,
+                        rangeEnd = rangeDuplicate.End,
                         OriginalText = originalText,
                         ReplacementText = replacement
                     };
                     this.ResultsList.Add(result);
+                    range.Start = containedWords.End + 1;
                 }
             }
 

--- a/Genizah/ThisAddIn.cs
+++ b/Genizah/ThisAddIn.cs
@@ -1,21 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Xml.Linq;
-using Word = Microsoft.Office.Interop.Word;
-using Office = Microsoft.Office.Core;
-using Microsoft.Office.Tools.Word;
 using System.Windows.Forms;
+using Genizah.Results;
 using Microsoft.Office.Interop.Word;
+using Microsoft.Office.Tools;
+using Word = Microsoft.Office.Interop.Word;
 
 namespace Genizah
 {
     public partial class ThisAddIn
     {
+        public List<SearchResult> ResultsList = new List<SearchResult>();
+        public ResultsControl resultsControl = new ResultsControl();
+        public CustomTaskPane resultsPane;
         private void ThisAddIn_Startup(object sender, EventArgs e)
         {
             Application.DocumentBeforePrint += new Word.ApplicationEvents4_DocumentBeforePrintEventHandler(Application_DocumentBeforePrint);
+            resultsPane = this.CustomTaskPanes.Add(resultsControl, "תוצאות");
         }
 
         private void ThisAddIn_Shutdown(object sender, EventArgs e)
@@ -42,6 +44,15 @@ namespace Genizah
                     cancel = true;
                 }
             }
+
+            // Remove Results HighLights
+            if (ResultsList.Count > 0)
+            {
+                foreach (var result in ResultsList)
+                {
+                    result.Bookmark.Range.HighlightColorIndex = 0;
+                }
+            }
         }
 
         /// <summary>
@@ -65,10 +76,13 @@ namespace Genizah
         /// </summary>
         public void CensorNames(Word.Document doc)
         {
+            this.ResultsList = new List<SearchResult>();
             foreach (var name in NameInfo.names)
             {
                 FindReplaceInDocument(doc, name.FindPattern, name.getSelectedReplacement());
             }
+            resultsControl.UpdateSearchResults(this.ResultsList);
+            resultsPane.Visible = true;
         }
 
         private bool FindReplaceInDocument(Word.Document doc, string target, string replacement, Word.WdReplace replaceMode = Word.WdReplace.wdReplaceAll)
@@ -78,23 +92,41 @@ namespace Genizah
 
             findObject.ClearFormatting();
             findObject.Replacement.ClearFormatting();
+            findObject.Text = target;
+            findObject.Forward = true;
+            findObject.Wrap = WdFindWrap.wdFindStop;
+            findObject.MatchWholeWord = false;
+            findObject.MatchWildcards = false;
+            findObject.MatchSoundsLike = false;
+            findObject.MatchAllWordForms = false;
+            findObject.MatchDiacritics = false;
+            findObject.MatchControl = false;
+            findObject.IgnorePunct = true;
 
-            findObject.Execute(
-                FindText: target,
-                MatchCase: true,
-                MatchWholeWord: false,
-                MatchWildcards: false,
-                MatchSoundsLike: false,
-                MatchAllWordForms: false,
-                Forward: true,
-                Wrap: WdFindWrap.wdFindStop,
-                Format: ref missing,
-                ReplaceWith: replacement,
-                Replace: replaceMode,
-                MatchKashida: false,
-                MatchDiacritics: false,
-                MatchAlefHamza: false,
-                MatchControl: false);
+            if (replaceMode == WdReplace.wdReplaceNone)
+            {
+                findObject.Execute(Format: ref missing, Replace: replaceMode);
+            }
+            else
+            {
+                while (findObject.Execute())
+                {
+                    var originalText = range.Text;
+                    range.Text = replacement;
+                    var bookmarkId = originalText + Guid.NewGuid().ToString().Split('-').First();
+                    Word.Bookmark bookmark = this.Application.ActiveDocument.Bookmarks.Add(bookmarkId, range);
+                    range.HighlightColorIndex = WdColorIndex.wdYellow;
+                    SearchResult result = new SearchResult()
+                    {
+                        Bookmark = bookmark,
+                        rangeStart = range.Start,
+                        rangeEnd = range.End,
+                        OriginalText = originalText,
+                        ReplacementText = replacement
+                    };
+                    this.ResultsList.Add(result);
+                }
+            }
 
             return findObject.Found;
         }
@@ -110,7 +142,7 @@ namespace Genizah
             this.Startup += new System.EventHandler(ThisAddIn_Startup);
             this.Shutdown += new System.EventHandler(ThisAddIn_Shutdown);
         }
-        
+
         #endregion
     }
 }


### PR DESCRIPTION
I added a custom task pane for reviewing the search and replace results and optionally undo each one.
It shows after a call to `CensorNames` was done,
each result is highlighted in the doc,
clicking on a result will select the replacement text in the doc.

![image](https://github.com/Pituchey-Hotam/Genizah/assets/77384873/c231a794-bd7f-4987-bd20-8a4556b2bc5e)
